### PR TITLE
Add support for && and || operators.

### DIFF
--- a/perfect-tower/main.lua
+++ b/perfect-tower/main.lua
@@ -358,8 +358,6 @@ function import(input)
 				if arg.type:match"^op_" then
 					if args[i]:match'^".*"$' then
 						args[i] = args[i]:sub(2, -2):lower()
-							:gsub("&&", "&")
-							:gsub("||", "|")
 							:gsub("^=$", "==")
 							:gsub("mod", "%%")
 							:gsub("pow", "^")

--- a/perfect-tower/scripts/lexer-operators.lua
+++ b/perfect-tower/scripts/lexer-operators.lua
@@ -23,8 +23,10 @@ local operators = [[
 > compare
 >= compare
 
+&& compare
 & compare
 
+|| compare
 | compare
 
 = assign


### PR DESCRIPTION
Also remove the filtering on import that purges them.

The game prefers && and || (you can't even select the single-char versions in the drop-down), so let's support that syntax for minimal friction.