### PR TITLE
Add macro functions, plus example text.

### DIFF
--- a/perfect-tower/index.html
+++ b/perfect-tower/index.html
@@ -446,9 +446,12 @@ gotoif(99, c.i(3, var, 3))`;
 ;   Labels are special variables. They are automatically replaced by a line number, and
 ;   exist to make 'goto' and 'gotoif' easier to use
 ; A line starting with a hashtag '#' is defining a macro
-;   Unlike labels, macros can only be used on lines after their definition
-;   Macros can reference other macros
+;   Simple macros are #macro_name macro_body
+;   Macro-functions can be be defined with #macro_name(arg1, arg2, ...) macro_body
+;   Macros can reference other macros, and also be nested inside macro calls
 ;   Macros are referenced using curly brackets '{}' and act as text replacement
+;   An example: "#concat(a, b) {a}{b}" defines a macro function that combines its arguments
+;   {co{concat(nc,at)}at("hi, there")} would result in "hi there" by applying it twice
 ;   Useful when dealing with large amounts of copy-pasted code
 ; Operators, and their precedence:
 ;   =               assign. Can be prefixed with other operators.

--- a/perfect-tower/index.html
+++ b/perfect-tower/index.html
@@ -451,7 +451,7 @@ gotoif(99, c.i(3, var, 3))`;
 ;   Macros can reference other macros, and also be nested inside macro calls
 ;   Macros are referenced using curly brackets '{}' and act as text replacement
 ;   An example: "#concat(a, b) {a}{b}" defines a macro function that combines its arguments
-;   {co{concat(nc,at)}at("hi, there")} would result in "hi there" by applying it twice
+;   {co{concat(nc,at)}("hi, there")} would result in "hi there" by applying it twice
 ;   Useful when dealing with large amounts of copy-pasted code
 ; Operators, and their precedence:
 ;   =               assign. Can be prefixed with other operators.


### PR DESCRIPTION
You can see this in action at: https://d0sboots.github.io/Kyromyr.github.io/perfect-tower/
A motivating example for why this is needed is: https://github.com/d0sboots/PerfectTower/commit/dca96f4788ddab70e2a4fd8a6d3ba95a099f42c3

Also, I tried to follow your coding style as much as possible, which included no comments. However, the parseMacro implementation could probably use comments, and I'm happy to add them if you want.

------------------

Macro functions work much like C's preprocessor macro functions, but
with some tweaks since this language uses curly-braces for
macro-expansion instead of expanding bare words. The defining syntax is
 #macro(arg1, arg2, ...) body
while using them is {macro(arg1,arg2,...)}. (Whitespace is not
significant in the argument list when defining a macro function, but it
*is* significant when calling them.)

Parenthesis must be balanced inside a macro call, and commas only
separate arguments at the outermost nesting level. This allows for
things like {macro(if(condition, 0, 1), "error msg")} to work as
expected, at the cost of disallowing things like {macro("(")}. (Using
extra macro trickery can achieve the latter if it's really needed.)

This also expands the syntax to allow for nesting macro calls, even for
non-functions - i.e. {foo{bar}}. Technically that by itself gives a
great deal of additional power, but not as much as functions give.

This changes the evaluation of macros to be evaluated at call time
instead of define time. This doesn't change the semantics of any
previously valid programs, but does allow for newly valid ones where
macros can refer to macros that aren't defined yet. It also means you
can have infinite recursion - this is guarded with a counter.