### PR TITLE
Add len() and lua() built-in macro functions.

### DIFF
--- a/perfect-tower/index.html
+++ b/perfect-tower/index.html
@@ -451,8 +451,12 @@ gotoif(99, c.i(3, var, 3))`;
 ;   Macros can reference other macros, and also be nested inside macro calls
 ;   Macros are referenced using curly brackets '{}' and act as text replacement
 ;   An example: "#concat(a, b) {a}{b}" defines a macro function that combines its arguments
-;   {co{concat(nc,at)}("hi, there")} would result in "hi there" by applying it twice
-;   Useful when dealing with large amounts of copy-pasted code
+;     {co{concat(nc,at)}("hi, there")} would result in "hi there" by applying it twice
+;   There are two builtin macro-functions: {len()} returns the length of its
+;     argument (including any whitespace), and {lua()} evaluates its argument
+;     as a Lua chunk (don't forget to return a value!).
+;   Macros are useful when dealing with large amounts of copy-pasted code,
+;     and macro-functions are good for more complicated code-generation needs.
 ; Operators, and their precedence:
 ;   =               assign. Can be prefixed with other operators.
 ;                      Must be the second thing on a line, after a variable name!


### PR DESCRIPTION
Preview as usual at https://d0sboots.github.io/Kyromyr.github.io/perfect-tower/

----

len() returns the length of its argument, including any whitespace.
lua() evaluates its argument as a Lua chunk. This can be used for simple constant folding, or for more complicated code generation. Originally it was an expression (it prepended `return`), but most of the use-cases ended up being more complicated, and while it's easy to add `return` yourself, the workarounds the other way require an anonymous function, which is more annoying.

An example of what motivates lua() is a macro like the following:
```
#combine(expr) {lua(local x = {expr}; if x == 0 then return "" end return "+ " .. x)}
```
This will constant-fold expressions (arithmetic is similar enough between Lua and perfect-tower-lang for this to work), and if the result is 0 the whole thing is dropped, eliminating needless extra expressions. This can be embedded inside a larger macro, promoting code re-use without requiring redundant arithmetic in the compiled result.

----

I don't anticipate adding any more built-in functions, because lua() is powerful enough to basically cover everything. len() is a nice convenience, plus it can't (easily) be emulated by lua() in the presence of quotes. The only thing I'd be likely to add is some kind of include/import feature.

