### PR TITLE
Add the ability to backslash-continue lines.

### DIFF
--- a/perfect-tower/main.lua
+++ b/perfect-tower/main.lua
@@ -144,10 +144,17 @@ function compile(name, input, testing)
 	local macros = {};
 	local lines = {};
 	local labelCache = {};
+	local lineCache = {};
 
-	for line in input:gmatch"[^\n]*" do
-		line = line:gsub("^%s+", ""):gsub("%s+$", "");
+	for real_line in input:gmatch"[^\n]*" do
 		line_number = line_number + 1;
+		if real_line:sub(-1) == "\\" then
+			lineCache[#lineCache+1] = real_line:sub(1, -2);
+			goto continue;
+		end
+		lineCache[#lineCache+1] = real_line;
+		line = table.concat(lineCache):gsub("^%s+", ""):gsub("%s+$", "");
+		lineCache = {};
 
 		if line:match"^#" then
 			local macro_args = "";
@@ -222,6 +229,7 @@ function compile(name, input, testing)
 				labelCache = {};
 			end
 		end
+		::continue::
 	end
 
 	for _, line in ipairs (lines) do


### PR DESCRIPTION
As I mentioned previously, this has the greatest use for lua(), but it's also quite useful for regular code. At least one other person expressed interest in it for their code already.
Macros are a workaround, but it's clumsy to have to break long lines into several sub-macros, just to have them fit into the space readably.

This is likely to be my last PR, unless I find random bugs that need fixing. The other things I want to do build on lua(), or just generally fall outside the bounds of what you want to do.

------

This is done very early in parsing, so that it works for both regular
lines and macro definitions. This means it also continues comments, with
the unintuitive result that the comment continues onto the next line.

This should not break any existing programs, because backslash was never
valid at the end of a line before - it would have only been legal inside
strings, which couldn't wrap lines.