### PR TITLE
Add documentation and examples for things that were missing.

### DIFF
--- a/perfect-tower/index.html
+++ b/perfect-tower/index.html
@@ -408,34 +408,11 @@
 			}, 500);
 		});
 
-		var scriptTemplate = `:local int i
-:local double test
-:local string var
-
-wakeup()
-
-isfill()
-
-i = 0
-label:
-	dig(i % 4, i / 4)
-	i += 1
-	gotoif(label, i == 1)
-
-i = label * 5
-
-global.int.set("a*b", (i - 1) * 2)
-var = "a*b"
-gis(var, (i - 1) * 2)
-
-var = '+'
-test = a.d(3., var, 0.)
-var = "=="
-gotoif(99, c.i(3, var, 3))`;
-
 		output.placeholder = `; Here's a tutorial, and a quick script to showcase it
 ;   New scripts start with this code, so don't worry about copying it by hand!
 ; Everything after a semicolon ';' is a comment. It doesn't get saved with the script
+; A line that ends with a backslash '\\' continues to the next line.
+;   This works even for comments, which is probably not what you want/expect!
 ; A line starting with a colon ':' is declaring a variable
 ;   Variable names are a combination of letters, digits, dots '.' and underscores '_'
 ;   Names must start with a letter or underscore
@@ -464,7 +441,7 @@ gotoif(99, c.i(3, var, 3))`;
 ;   &               and
 ;   |               or
 ; Have fun!
-		
+
 :local int i
 :local double test
 :local string var
@@ -485,17 +462,26 @@ label:
 ; You can do math on labels, too!
 i = label * 5
 
+; This is how you can use macros to cut down on duplication
+#common_expr (i - 2) * (i - 1) / 2
+
 ; This is a valid way to use variables, too
-global.int.set("a*b", (i - 1) * 2)
+global.int.set("a*b", {common_expr})
 var = "a*b"
-gis(var, (i - 1) * 2)
+gis(var, {common_expr})
+
+; Continuing a long line. Note the space before the backslash,
+; that doesn't get included automatically.
+var = "This is a really long string that probably shouldn't keep \\
+going on like this and yet it does."
 
 ; This is how you use variables as operators
 var = '+' ; Single quotes works too
 test = a.d(3., var, 0.)
 var = "=="
-gotoif(99, c.i(3, var, 3))
-`;
+gotoif(99, c.i(3, var, 3))`;
+
+		var scriptTemplate = output.placeholder.split("Have fun!\n\n")[1];
 	</script>
 </body>
 </html>


### PR DESCRIPTION
Whoops, I forgot to add docs with this feature. To make this not completely trivial, I added some other docs too.

-----

Backslash-continuation wasn't documented. It also didn't have an
example.
Macros didn't have an example in the sample code, either.
This also makes the sample code *actually* be the code in the template,
instead of being a hardcoded copy.