### PR TITLE
More bug fixes for :const handling

### DIFF
--- a/perfect-tower/index.html
+++ b/perfect-tower/index.html
@@ -40,7 +40,7 @@
 			</div>
 
 			<div class="editor-info">
-				<span class="infotext">Editor: 1.44 ─ Game: v0.9.6 B1</span>
+				<span class="infotext">Editor: 1.45 ─ Game: v0.9.6 B1</span>
 				<span id="warning" class="infotext warning">Cannot access Local Storage. Scripts will not save!</span>
 				<select id="functionList" class="functionList"></select>
 			</div>

--- a/perfect-tower/main.lua
+++ b/perfect-tower/main.lua
@@ -82,7 +82,7 @@ local function cache(line, variables)
 	local key = {};
 
 	for _, v in pairs (variables) do
-		table.insert(key, string.format("%s.%s.%s", v.scope, v.type, v.name));
+		table.insert(key, string.format("%s.%s.%s.%s", v.scope, v.type, v.name, v.value));
 	end
 
 	table.sort(key);
@@ -182,7 +182,7 @@ function compile(name, input, testing)
 			assert(not macros[name], "macro already exists: " .. name);
 			macros[name] = {text=macro:gsub("{[^{}]+}", args), arg_len=arg_len};
 		elseif line:match"^:const" then
-			local _, type, name, value = line:sub(2):match("^(%a+) (%a+) " .. TOKEN.identifier.patternAnywhere .. " (.+)$");
+			local _, type, name, value = line:sub(2):gsub(" *;.*", ""):match("^(%a+) (%a+) " .. TOKEN.identifier.patternAnywhere .. " (.+)$");
 			assert(type == "int" or type == "double" or type == "string" or type == "bool", "constant types are 'int', 'double', 'string' and 'bool");
 			if (type == "int" or type == "double") then
 				assert((value:match"^%d+$" and type == "int") or (value:match"^%d+%.%d*$" and type == "double"), "bad argument, " .. type .. " expected, got " .. value);

--- a/perfect-tower/main.lua
+++ b/perfect-tower/main.lua
@@ -182,7 +182,7 @@ function compile(name, input, testing)
 			assert(not macros[name], "macro already exists: " .. name);
 			macros[name] = {text=macro:gsub("{[^{}]+}", args), arg_len=arg_len};
 		elseif line:match"^:const" then
-			local _, type, name, value = line:sub(2):gsub(" *;.*", ""):match("^(%a+) (%a+) " .. TOKEN.identifier.patternAnywhere .. " (.+)$");
+			local _, type, name, value = line:sub(2):match("^(%a+) (%a+) " .. TOKEN.identifier.patternAnywhere .. " (.+)$");
 			assert(type == "int" or type == "double" or type == "string" or type == "bool", "constant types are 'int', 'double', 'string' and 'bool");
 			if (type == "int" or type == "double") then
 				assert((value:match"^%d+$" and type == "int") or (value:match"^%d+%.%d*$" and type == "double"), "bad argument, " .. type .. " expected, got " .. value);


### PR DESCRIPTION
Fixes d0sboots/perfect-tower#5

* Allow comments after a :const declaration
* Add const value to the cache key, so that changes will properly
  recalculate, instead of re-using stale expression values. The nil in
  the value field works fine for the other variable types.
* Bump version to v1.45