### PR TITLE
Fix issue with string concat of number constants.

### DIFF
--- a/perfect-tower/scripts/lexer.lua
+++ b/perfect-tower/scripts/lexer.lua
@@ -187,7 +187,7 @@ local function consumeTokensWorker(node)
 						
 						if status then
 							const = true;
-							left.value = resolveType(left) == "int" and math.modf(ret) or ret;
+							left.value = resolveType(left) == "int" and op.value ~= "." and math.modf(ret) or ret;
 							if isNegativeRemainder then
 								left.value = -left.value;
 							end


### PR DESCRIPTION
Fixes d0sboots/perfect-tower#6

The issue comes during constant folding, i.e. when concatenating two
constants. If the left one is a number, the result would be taken as a
number instead of a string.
This was rarely/never encountered, because concat is left-associative,
and you rarely start a concat chain with a number.