### PR TITLE
Bump to game 0.11.0, version 1.58

### DIFF
--- a/perfect-tower/index.html
+++ b/perfect-tower/index.html
@@ -40,7 +40,7 @@
 			</div>
 
 			<div class="editor-info">
-				<span class="infotext">Editor: 1.57 ─ Game: v0.10.0 B1</span>
+				<span class="infotext">Editor: 1.58 ─ Game: v0.11.0 B1</span>
 				<span id="warning" class="infotext warning">Cannot access Local Storage. Scripts will not save!</span>
 				<select id="functionList" class="functionList"></select>
 			</div>

--- a/perfect-tower/scripts/lexer-functions.lua
+++ b/perfect-tower/scripts/lexer-functions.lua
@@ -11,7 +11,6 @@ local strings = {
 	machine = {"oven", "assembler", "refinery", "crusher", "cutter", "presser", "mixer", "shaper", "boiler"},
 
 	inventory = {"inventory", "equipped", "combinator", "cuboscube"},
-	elementMuseum = {"fire", "water", "earth", "air", "nature", "light", "darkness", "electricity"},
 	elementMarket = {"fire", "water", "earth", "air", "nature", "light", "darkness", "electricity", "universal"},
 	elementAll = {"fire", "water", "earth", "air", "nature", "light", "darkness", "electricity", "universal", "neutral"},
 
@@ -65,7 +64,6 @@ VALIDATOR = {
 	machine = function(value) return stringValid("machine", value, "Machines"); end,
 
 	inv = function(value) return stringValid("inventory", value, "Inventories"); end,
-	elementMuseum = function(value) return stringValid("elementMuseum", value, "Elements"); end,
 	elementMarket = function(value) return stringValid("elementMarket", value, "Elements"); end,
 	elementAll = function(value) return stringValid("elementAll", value, "Elements"); end,
 
@@ -273,18 +271,33 @@ void factory.craft(string:item[craft], int:tier[tier], double:amount) Factory
 void factory.produce(string:item[produce], int:tier[tier], double:amount, string:machine[machine]) Factory
 void factory.trash(string:item[item], int:tier[tier], double:amount) Factory
 
-bool museum.isfill() Museum
+bool museum.market.preference(string:element[elementMarket]) Museum #museum.preference#
+bool museum.market.slotLocked(int:offerSlot) Museum #museum.isSlotLocked#
 int museum.freeSlots(string:inventory[inv]) Museum
 int museum.stone.tier(string:inventory[inv], int:slot) Museum
+int museum.market.preferredTier() Museum #museum.preferredTier#
+int museum.market.maxTier(string:element[elementMarket]) Museum #museum.maxTier#
+int museum.market.slotTier(int:offerSlot) Museum #museum.slotTier#
+int museum.rebuy.tier(int:trashSlot) Museum #museum.trashTier#
+double museum.market.timer() Museum #museum.timer#
 string museum.stone.element(string:inventory[inv], int:slot) Museum
-void museum.fill(bool:enable) Museum
-void museum.buy(string:element[elementMuseum]) Museum
-void museum.buyMarket(string:element[elementMarket], int:tierMax) Museum
+string museum.market.slotElement(int:offerSlot) Museum #museum.slotElement#
+string museum.rebuy.element(int:trashSlot) Museum #museum.trashElement#
 void museum.combine(int:tierMax) Museum
 void museum.transmute() Museum
 void museum.move(string:from[inv], int:slot, string:to[inv]) Museum
 void museum.delete(string:inventory[inv], int:slot) Museum
 void museum.clear(string:inventory[inv]) Museum
+void museum.stone.buy(string:element[elementMarket], int:tier, int:quantity) Museum #museum.buyTier#
+void museum.stone.buyRange(string:element[elementMarket], int:tierMin, int:tierMax, int:quantity) Museum #museum.buyRange#
+void museum.moveSlot(string:from[inv], int:fromSlot, string:to[inv] int:toSlot) Museum #museum.moveTo#
+void museum.swap(string:invA[inv], int:slotA, string:invB[inv] int:slotB) Museum #museum.swap#
+void museum.market.set.preferredTier(int:tier) Museum #museum.setPreferredTier#
+void museum.market.set.preference(string:element[elementMarket], bool) Museum #museum.setPreference#
+void museum.market.refresh() Museum #museum.refresh#
+void museum.market.buy(int:offerSlot, int:quantity) Museum #museum.buyOffer#
+void museum.market.set.slotLocked(int:offerSlot, bool:locked) Museum #museum.setSlotLocked#
+void museum.rebuy.buy(int:trashSlot) Museum #museum.rebuy#
 
 int tradingpost.offerCount() Trading Post
 void tradingpost.refresh() Trading Post


### PR DESCRIPTION
It looks like everything has settled and is about to release, so time to send this out.

* Add 19 new "museum" functions
* Remove 4 deprecated museum functions
* Remove "museumElement" enum type, which is no longer used

Even though the deprecated functions are technically still in the game, they don't function anymore, so I think it's best that they compile-error.

The short names have some editorializing, they aren't all directly taken from the game's function names. For instance `museum.market.buy` becomes "museum.buyTier", to better reflect its function.

If you have any changes to make to the naming, it would be good to know sooner, so I can also adjust on my end.